### PR TITLE
fix: Remove version specifications from package references in Maui

### DIFF
--- a/src/Client/GoldBazar.Client.Maui/GoldBazar.Client.Maui.csproj
+++ b/src/Client/GoldBazar.Client.Maui/GoldBazar.Client.Maui.csproj
@@ -61,9 +61,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="$(MauiVersion)" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Maui.Controls" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Debug" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fix: Remove PackageReference Version Attributes for Central Package Version Management (CPVM)

This PR resolves a build issue caused by defining package versions directly in .csproj files while using Central Package Version Management (CPVM).